### PR TITLE
Correct path for `uninstall` task in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,4 @@ clean:
 	rm -rf .build
 
 uninstall:
-	rm -f /usr/local/needless
-
+	rm -f /usr/local/bin/needless


### PR DESCRIPTION
The `uninstall` task now points to the same location that the binary was moved to in the `install` task.